### PR TITLE
Update vencord patches

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -277,7 +277,7 @@ export default definePlugin({
         {
             find: '?"@":"",',
             replacement: {
-                match: /(?<=children:)\(\i\?"@":""\)\+\i(?=,|\})/,
+                match: /(?<=onContextMenu:\i,children:).*?}/,
                 replace: "$self.renderUsername(arguments[0])"
             }
         },

--- a/index.tsx
+++ b/index.tsx
@@ -277,8 +277,8 @@ export default definePlugin({
         {
             find: '?"@":""',
             replacement: {
-                match: /(?<=onContextMenu:\i,children:).*?}/,
-                replace: "$self.renderUsername(arguments[0])}"
+                match: /(?<=children:)\(\i\?"@":""\)\+\i(?=,|\})/,
+                replace: "$self.renderUsername(arguments[0])"
             }
         },
         // make up arrow to edit most recent message work

--- a/index.tsx
+++ b/index.tsx
@@ -215,7 +215,7 @@ export default definePlugin({
             find: ")?\"gif\":\"jpg\";",
             replacement: {
                 match: /(?<=\){)let \i,{endpoint:.*=.;/,
-                replace: "if($self.fronterPfp(arguments[0].id))return $self.fronterPfp(arguments[0].id);$&"
+                replace: "if($self.checkFronterPfp(arguments[0].id))return $self.fronterPfp(arguments[0].id);$&"
             }
         },
         {
@@ -326,17 +326,26 @@ export default definePlugin({
     },
 
     saveTimestamp: ({message}) => {
+        if(!getUserSystem(message.author.id, pluralKit.api))
+            return;
+
+        savedTimestamp = new Date();
         if(message?.timestamp)
             savedTimestamp = new Date(message.timestamp);
     },
 
-    fronterPfp: (userId) => {
+    checkFronterPfp: (userId) => {
         const pkAuthor = getUserSystem(userId, pluralKit.api);
         const messageIter = pkAuthor?.switches?.values();
         const messageSwitch = messageIter?.filter((switchObj) => {return savedTimestamp >= switchObj?.timestamp})?.next?.();
         const member = messageSwitch?.value?.members?.values?.()?.next?.();
         const url = member?.value?.avatar_url;
         return url;
+    },
+
+    fronterPfp: (userId) => {
+        const pfp = pluralKit.checkFronterPfp(userId);
+        return pfp;
     },
 
     getCurrentUser: (defaultUser) => {

--- a/index.tsx
+++ b/index.tsx
@@ -254,7 +254,7 @@ export default definePlugin({
             }
         },
         {
-            find: "PENDING_INCOMING&&(0,",
+            find: ".hasAvatarForGuild(null==",
             replacement: {
                 match: /let{user:\i/,
                 replace: "arguments[0].user=$self.getUserPopoutMessageSender(arguments[0]) ?? arguments[0].user;$&"
@@ -275,7 +275,7 @@ export default definePlugin({
             }
         },
         {
-            find: '?"@":""',
+            find: '?"@":"",',
             replacement: {
                 match: /(?<=children:)\(\i\?"@":""\)\+\i(?=,|\})/,
                 replace: "$self.renderUsername(arguments[0])"
@@ -286,7 +286,7 @@ export default definePlugin({
         // using that plugin, you'll have enough problems with pk already
         // Stolen directly from https://github.com/lynxize/vencord-plugins/blob/plugins/src/userplugins/pk4vc/index.tsx
         {
-            find: "getLastEditableMessage",
+            find: "}getLastEditableMessage",
             replacement: {
                 match: /return (.)\(\)\(this.getMessages\((.)\).{10,100}:.\.id\)/,
                 replace: "return $1()(this.getMessages($2).toArray()).reverse().find(msg => $self.isOwnMessage(msg)"

--- a/install/install_pk_integration.ps1
+++ b/install/install_pk_integration.ps1
@@ -44,8 +44,7 @@ function Main {
 		})
 	)
 
-	$PathSeparator = [IO.Path]::DirectorySeparatorChar
-	$SrcDirectory = "$([Environment]::GetFolderPath("MyDocuments"))$($PathSeperator)src"
+	$SrcDirectory = Join-Path -Path "$([Environment]::GetFolderPath("MyDocuments"))" -ChildPath "src"
 	Mkdir-CD $SrcDirectory
 	Write-Host "Installation located at $SrcDirectory" -ForegroundColor "Gray"
 
@@ -72,7 +71,7 @@ function Main {
 	$VencordType = $Host.UI.PromptForChoice("Vencord Version Query", "What version of Vencord do you use?", $VencordTypes, 0)
 
 	Write-Host "Building $($VencordTypes[$VencordType])" -ForegroundColor "Gray"
-	$DistDirectory = "$SrcDirectory$($PathSeparator)dist"
+	$DistDirectory = Join-Path -Path "$SrcDirectory" -ChildPath "dist"
 	switch ($VencordType) {
 		# Vencord
 		0 {
@@ -240,7 +239,7 @@ function Mkdir-CD {
 	param ( [string] $directory )
 
 	if(-Not (Test-Path -Path "$directory")){
-		New-Item -Name "$directory" -ItemType Directory
+		New-Item -Path "$directory" -ItemType Directory
 	}
 
 	cd $directory


### PR DESCRIPTION
Fixes the find syntax on 2 patches that had more than 1 find result each.

Also reverts your change to the renderUsername patch. The existing patch worked correctly (at least for me), and the new one does not, as the regex fails to match. Added a comma to the find syntax as an afterthought, but it isn't necessary as there are no other matches.